### PR TITLE
npair loss for latent_position model for fair comparison

### DIFF
--- a/metric_learning/configurations.py
+++ b/metric_learning/configurations.py
@@ -16,7 +16,7 @@ configs = {
                 'data_directory': '/tmp/research/experiment/stanford_online_product/train',
                 'batch_size': 32,
                 'group_size': 2,
-                'num_groups': 8,
+                'num_groups': 16,
                 'min_class_size': 2,
             },
             'test': {
@@ -36,6 +36,9 @@ configs = {
             'loss': {
                 'name': 'latent_position',
                 'parametrization': 'bias',
+                'npair': {
+                    'n': 16,
+                },
                 'alpha': 8,
             },
             'metric': 'euclidean_distance',
@@ -148,10 +151,12 @@ configs = {
             'name': 'simple_dense',
             'k': 8,
             'loss': {
-                'name': 'npair',
-                'n': 4,
-                'parametrization': 'euclidean_distance',
+                'name': 'latent_position',
+                'parametrization': 'bias',
                 'alpha': 4.0,
+                'npair': {
+                    'n': 4,
+                },
             },
             'metric': 'euclidean_distance',
         },

--- a/metric_learning/loss_functions/tests/latent_position_loss_test.py
+++ b/metric_learning/loss_functions/tests/latent_position_loss_test.py
@@ -15,7 +15,7 @@ class LatentPositionLossTest(tf.test.TestCase):
             [0, 2],
             [0, 3],
         ])
-        y = pairwise_euclidean_distance_squared(embeddings)
+        y = pairwise_euclidean_distance_squared(embeddings, embeddings)
         self.assertAllEqual(y, [
             [0, 1, 4],
             [1, 0, 1],
@@ -28,7 +28,7 @@ class LatentPositionLossTest(tf.test.TestCase):
             [0, 2],
             [0, 3],
         ])
-        y = pairwise_dot_product(embeddings)
+        y = pairwise_dot_product(embeddings, embeddings)
         self.assertAllEqual(y, [
             [1, 2, 3],
             [2, 4, 6],

--- a/metric_learning/loss_functions/tests/npair_loss_test.py
+++ b/metric_learning/loss_functions/tests/npair_loss_test.py
@@ -1,6 +1,6 @@
 import tensorflow as tf
 
-from metric_learning.loss_functions.npair_loss import sample_npair
+from metric_learning.loss_functions.npair_loss import group_npairs
 from metric_learning.loss_functions.npair_loss import compute_dot_product_exponents
 from metric_learning.loss_functions.npair_loss import compute_euclidean_distance_exponents
 
@@ -23,7 +23,7 @@ class NpairLossTest(tf.test.TestCase):
         labels = tf.constant([
             0, 0, 1, 1, 2, 2, 3, 3, 4, 4
         ])
-        first_images, second_images = sample_npair(images, labels, 4)[0]
+        first_images, second_images = group_npairs(images, labels, 4)[0]
         self.assertAllEqual(first_images, [[0., 1.], [0., 3.], [0., 5.], [0., 7.]])
         self.assertAllEqual(second_images, [[0., 2.], [0., 4.], [0., 6.], [0., 8.]])
 
@@ -41,7 +41,7 @@ class NpairLossTest(tf.test.TestCase):
         labels = tf.constant([
             0, 0, 1, 1, 2, 2, 3, 3, 4, 4
         ])
-        first_images, second_images = sample_npair(images, labels, 4)[0]
+        first_images, second_images = group_npairs(images, labels, 4)[0]
         exponents = compute_dot_product_exponents(first_images, second_images)
         self.assertAllEqual(exponents, [
             [0., 2., 4., 6.],
@@ -64,7 +64,7 @@ class NpairLossTest(tf.test.TestCase):
         labels = tf.constant([
             0, 0, 1, 1, 2, 2, 3, 3, 4, 4
         ])
-        first_images, second_images = sample_npair(images, labels, 4)[0]
+        first_images, second_images = group_npairs(images, labels, 4)[0]
         exponents = compute_euclidean_distance_exponents(first_images, second_images)
         self.assertAllEqual(exponents, [
             [  0.,   0.,  -8., -24.],

--- a/util/dataset.py
+++ b/util/dataset.py
@@ -94,3 +94,24 @@ def save_image_files(image_files, save_dir):
         if not os.path.exists(os.path.dirname(dest)):
             os.makedirs(os.path.dirname(dest))
         copyfile(image_file, dest)
+
+
+def group_npairs(images, labels, n):
+    ret = []
+    for batch in range(int(images.shape[0]) // (n * 2)):
+        cur_labels = labels[batch * n * 2: (batch + 1) * n * 2]
+        cur_images = images[batch * n * 2: (batch + 1) * n * 2]
+        data_map = defaultdict(list)
+        for index, label in enumerate(cur_labels):
+            data_map[int(label)].append(index)
+
+        first_images = []
+        second_images = []
+        for label in data_map.keys():
+            first_images.append(cur_images[data_map[label][0]])
+            second_images.append(cur_images[data_map[label][1]])
+        ret.append((
+            tf.stack(first_images),
+            tf.stack(second_images),
+        ))
+    return ret


### PR DESCRIPTION
Use npair batch scheme for latent_position model so that the number of pairs that the model process matches that of n-tuplet model.