### PR TITLE
Cross validation

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -14,3 +14,5 @@ checkpoint_period = 1000
 data_dir = /tmp/research/data
 temp_dir = /tmp/research/temp
 experiment_dir = /tmp/research/experiment
+
+cross_validation_splits = 5

--- a/metric_learning/configurations.py
+++ b/metric_learning/configurations.py
@@ -17,14 +17,12 @@ configs = {
         'dataset': {
             'name': 'stanford_online_product',
             'train': {
-                'data_directory': '{}/stanford_online_product/train'.format(experiment_dir),
                 'batch_size': 32,
                 'group_size': 2,
                 'num_groups': 16,
                 'min_class_size': 2,
             },
             'test': {
-                'data_directory': '{}/stanford_online_product/test'.format(experiment_dir),
                 'identification': {
                     'num_negative_examples': 5,
                     'num_testcases': 10000,
@@ -129,14 +127,12 @@ configs = {
         'dataset': {
             'name': 'mnist',
             'train': {
-                'data_directory': '{}/mnist/train'.format(experiment_dir),
                 'batch_size': 8,
                 'group_size': 2,
                 'num_groups': 4,
                 'min_class_size': 2,
             },
             'test': {
-                'data_directory': '{}/mnist/test'.format(experiment_dir),
                 'identification': {
                     'num_negative_examples': 1,
                     'num_testcases': 1000,

--- a/metric_learning/evaluate.py
+++ b/metric_learning/evaluate.py
@@ -6,7 +6,7 @@ import json
 import os
 
 from util.config import CONFIG
-from util.dataset import create_dataset_from_directory
+from util.dataset import load_images_from_directory
 
 from util.registry.model import Model
 from util.registry.metric import Metric
@@ -77,8 +77,8 @@ if __name__ == '__main__':
                                      optimizer_step=tf.train.get_or_create_global_step())
     checkpoint.restore(get_checkpoint(args.experiment))
 
-    testing_files, testing_labels = create_dataset_from_directory(
-        conf['dataset']['test']['data_directory']
+    testing_files, testing_labels = load_images_from_directory(
+        os.path.join(CONFIG['dataset']['experiment_dir'], conf['dataset']['name'], 'test'),
     )
     data_loader = DataLoader.create(conf['dataset']['name'], conf)
     test_datasets = {}

--- a/metric_learning/prepare_dataset.py
+++ b/metric_learning/prepare_dataset.py
@@ -4,6 +4,7 @@ from util.registry.data_loader import DataLoader
 from util.config import CONFIG
 
 import argparse
+import random
 import shutil
 import os
 
@@ -12,23 +13,33 @@ if __name__ == '__main__':
     tf.enable_eager_execution()
 
     parser = argparse.ArgumentParser(
-        description='Prepare dataset for training/testing models')
+        description='Download dataset for training/testing models')
     parser.add_argument('--dataset', help='Name of the dataset')
-    parser.add_argument('--dir', help='Directory to save training/testing datasets')
 
     args = parser.parse_args()
 
-    directory = args.dir
-    if directory is None:
-        directory = os.path.join(CONFIG['dataset']['experiment_dir'], args.dataset)
+    directory = os.path.join(CONFIG['dataset']['experiment_dir'], args.dataset)
 
     data_loader: DataLoader = DataLoader.create(args.dataset)
     data_loader.prepare_files()
 
-    shutil.rmtree(os.path.join(directory, 'train'), ignore_errors=True)
+    # copy test data
     shutil.rmtree(os.path.join(directory, 'test'), ignore_errors=True)
+    shutil.copytree(
+        os.path.join(CONFIG['dataset']['data_dir'], args.dataset, 'test'),
+        os.path.join(directory, 'test'))
 
-    for split in ['train', 'test']:
-        shutil.copytree(
-            os.path.join(CONFIG['dataset']['data_dir'], args.dataset, split),
-            os.path.join(directory, split))
+    # cross validation splits
+    shutil.rmtree(os.path.join(directory, 'train'), ignore_errors=True)
+    splits = list(range(CONFIG['dataset']['cross_validation_splits']))
+    for k in splits:
+        if not tf.gfile.Exists(os.path.join(directory, 'train', str(k))):
+            tf.gfile.MakeDirs(os.path.join(directory, 'train', str(k)))
+    for root, dirnames, filenames in os.walk(os.path.join(CONFIG['dataset']['data_dir'], args.dataset, 'train')):
+        for filename in filenames:
+            split = random.choice(splits)
+            dest_filename = os.path.join(root.split('/')[-1], filename)
+            dest_dir = os.path.join(directory, 'train', str(split))
+            if not tf.gfile.Exists(os.path.dirname(os.path.join(dest_dir, dest_filename))):
+                tf.gfile.MakeDirs(os.path.dirname(os.path.join(dest_dir, dest_filename)))
+            shutil.copy(os.path.join(root, filename), os.path.join(directory, 'train', str(split), dest_filename))

--- a/scripts/test_data_perf.py
+++ b/scripts/test_data_perf.py
@@ -5,7 +5,7 @@ tf.enable_eager_execution()
 from util.registry.model import Model
 from util.registry.data_loader import DataLoader
 
-from util.dataset import create_dataset_from_directory
+from util.dataset import load_images_from_directory
 
 import time
 
@@ -52,7 +52,7 @@ print(int(time.time() - now), 'model loaded')
 
 data_loader: DataLoader = DataLoader.create(conf['dataset']['name'], conf)
 
-testing_files, testing_labels = create_dataset_from_directory(
+testing_files, testing_labels = load_images_from_directory(
     conf['dataset']['test']['data_directory']
 )
 test_ds = data_loader.create_identification_test_dataset(testing_files, testing_labels).batch(32).prefetch(32)

--- a/util/dataset.py
+++ b/util/dataset.py
@@ -48,12 +48,16 @@ def extract_zip(filepath, directory):
         zip_ref.extractall(directory)
 
 
-def create_dataset_from_directory(directory):
+def load_images_from_directory(directory, splits=None):
     label_map = {}
     labels = []
     image_files = []
     for subdir, dirs, files in os.walk(directory):
         for file in files:
+            if splits:
+                split = int(subdir.split('/')[-2])
+                if split not in splits:
+                    continue
             label = subdir.split('/')[-1]
             if label not in label_map:
                 label_map[label] = len(label_map) + 1

--- a/util/registry/data_loader.py
+++ b/util/registry/data_loader.py
@@ -1,5 +1,5 @@
 from util.registry.class_registry import ClassRegistry
-from util.dataset import create_dataset_from_directory
+from util.dataset import load_images_from_directory
 from collections import defaultdict
 from util.config import CONFIG
 
@@ -159,7 +159,7 @@ class DataLoader(object, metaclass=ClassRegistry):
 
     def load_image_files(self):
         self.prepare_files()
-        image_files, labels = create_dataset_from_directory(
+        image_files, labels = load_images_from_directory(
             os.path.join(CONFIG['dataset']['data_dir'], self.name))
         return image_files, labels
 


### PR DESCRIPTION
- randomly split training data into k(=5) splits when prepare_dataset.py is run
- run.py now uses one of the splits(can be specified by --split flag) as validation dataset and the rest as training dataset
- cleaned up configurations.py

Note:
- there are some changes to default.conf. Need to copy the new default.conf to ~/.metric_learning.conf
- remove all datasets in /tmp/research/experiment
- rerun prepare_dataset.py for all datasets.

issue: https://github.com/hominot/research/issues/23