### PR TITLE
New experiments

### DIFF
--- a/metric_learning/experiments/contrastive_new.json
+++ b/metric_learning/experiments/contrastive_new.json
@@ -1,0 +1,19 @@
+{
+  "image": [{}],
+  "dataset": [
+    {"name": "cub200"},
+    {"name": "cars196"}
+  ],
+  "batch_design": [
+    {"name": "grouped", "group_size": 4, "batch_size": 64}
+  ],
+  "model": [{"name": "resnet50", "dimension": 128}],
+  "loss": [
+    {"name": "contrastive", "alpha": 4.0, "new_importance_sampling": true}
+  ],
+  "metrics": [{"recall": true, "auc": true, "nmi": true, "vrf": true}],
+  "trainer": [
+    {"learning_rate": 0.00003, "lr_decay_steps": 100, "lr_decay_rate": 0.9, "num_epochs": 20},
+    {"learning_rate": 0.0001, "lr_decay_steps": 100, "lr_decay_rate": 0.9, "num_epochs": 20}
+  ]
+}

--- a/metric_learning/experiments/contrastive_new_stanford.json
+++ b/metric_learning/experiments/contrastive_new_stanford.json
@@ -1,0 +1,18 @@
+{
+  "image": [{}],
+  "dataset": [
+    {"name": "stanford_online_product"}
+  ],
+  "batch_design": [
+    {"name": "grouped", "group_size": 4, "batch_size": 64}
+  ],
+  "model": [{"name": "resnet50", "dimension": 128}],
+  "loss": [
+    {"name": "contrastive", "alpha": 10.0, "new_importance_sampling": true}
+  ],
+  "metrics": [{"recall": true, "auc": true, "vrf": true}],
+  "trainer": [
+    {"learning_rate": 0.0001, "lr_decay_steps": 100, "lr_decay_rate": 0.9, "num_epochs": 20},
+    {"learning_rate": 0.0001, "lr_decay_steps": 100, "lr_decay_rate": 0.9, "num_epochs": 20}
+  ]
+}

--- a/metric_learning/experiments/importance_sampling_data_distortion_new.json
+++ b/metric_learning/experiments/importance_sampling_data_distortion_new.json
@@ -1,0 +1,26 @@
+{
+  "image": [{}],
+  "dataset": [
+    {"name": "cub200", "distort": 0.1},
+    {"name": "cub200", "distort": 0.2},
+    {"name": "cub200", "distort": 0.3},
+    {"name": "cub200", "distort": 0.4},
+    {"name": "cub200", "distort": 0.5},
+    {"name": "cub200", "distort": 0.6},
+    {"name": "cub200", "distort": 0.7},
+    {"name": "cub200", "distort": 0.8},
+    {"name": "cub200", "distort": 0.9},
+    {"name": "cub200", "distort": 1.0}
+  ],
+  "batch_design": [
+    {"name": "grouped", "group_size": 4, "batch_size": 64}
+  ],
+  "model": [{"name": "resnet50", "dimension": 128}],
+  "loss": [
+    {"name": "contrastive", "alpha": 4.0, "new_importance_sampling": true}
+  ],
+  "metrics": [{"recall": true, "auc": true, "nmi": true}],
+  "trainer": [
+    {"learning_rate": 0.00003, "lr_decay_steps": 100, "lr_decay_rate": 0.9, "num_epochs": 20}
+  ]
+}

--- a/metric_learning/experiments/importance_sampling_num_negatives.json
+++ b/metric_learning/experiments/importance_sampling_num_negatives.json
@@ -1,0 +1,26 @@
+{
+  "image": [{}],
+  "dataset": [
+    {"name": "cub200"}
+  ],
+  "batch_design": [
+    {"name": "grouped", "group_size": 4, "batch_size": 64}
+  ],
+  "model": [{"name": "resnet50", "dimension": 128}],
+  "loss": [
+    {"name": "contrastive", "alpha": 4.0, "importance_sampling": true, "l": 1},
+    {"name": "contrastive", "alpha": 4.0, "importance_sampling": true, "l": 2},
+    {"name": "contrastive", "alpha": 4.0, "importance_sampling": true, "l": 4},
+    {"name": "contrastive", "alpha": 4.0, "importance_sampling": true, "l": 8},
+    {"name": "contrastive", "alpha": 4.0, "importance_sampling": true, "l": 16},
+    {"name": "contrastive", "alpha": 4.0, "importance_sampling": true, "l": 32},
+    {"name": "contrastive", "alpha": 4.0, "importance_sampling": true, "l": 64},
+    {"name": "contrastive", "alpha": 4.0, "importance_sampling": true, "l": 128},
+    {"name": "contrastive", "alpha": 4.0, "importance_sampling": true, "l": 256},
+    {"name": "contrastive", "alpha": 4.0, "importance_sampling": true, "l": 512}
+  ],
+  "metrics": [{"recall": true, "auc": true, "nmi": true, "vrf": true}],
+  "trainer": [
+    {"learning_rate": 0.00003, "lr_decay_steps": 100, "lr_decay_rate": 0.9, "num_epochs": 20}
+  ]
+}


### PR DESCRIPTION
contrastive_new (4): 기존의 contrastive 결과와 union
contrastive_new_stanford (2) : 기존의 contrastive 결과와 union
importance_sampling_data_distortion_new (10): 기존의 importance_sampling_data_distortion을 대체
importance_sampling_num_negatives (10): 새로운 실험. 결과를 보고 그래프를 추가할지 text로 설명할지 결정.

괄호 안의 숫자는 실험 개수입니다. 총 26개의 실험이 추가되겠네요. 모두 contrastive loss입니다.
꼭 최신 코드로 git pull한 후에 실험 등록 해주시기 바랍니다.